### PR TITLE
feat: update plugin to 0.2.x so that fixed are auto-applied

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@ rootProject.name = "dev.hytalemodding"
 
 plugins {
     // See documentation on https://scaffoldit.dev
-    id("dev.scaffoldit") version "0.2.4"
+    id("dev.scaffoldit") version "0.2.+"
 }
 
 // Would you like to do a split project?
@@ -10,7 +10,7 @@ plugins {
 
 hytale {
     usePatchline("release")
-    useVersion("+")
+    useVersion("latest")
 
     repositories {
         // Any external repositories besides: MavenLocal, MavenCentral, HytaleMaven, and CurseMaven


### PR DESCRIPTION
Changing to a more open version matcher so that bugfixes would be auto-applied. The overall idea is that the major and minor versions reflect Hytale, where we are on update 2 now. Once update 3 is out, this would roll to 0.3.x and so on.

Update for 0.2.5:
- Fix devserver module resolution and subsequent reset on non-match