### PR TITLE
Fixes for VSCode and Jar Name not updating when building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ run/
 .classpath
 .project
 .settings/
+.vscode

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,11 @@ repositories {
     mavenCentral()
 }
 
+tasks.named<Jar>("jar") {
+    archiveBaseName.set(project.property("mod_name").toString())
+    archiveVersion.set(project.property("version").toString())
+}
+
 // Uncomment if you are using IntelliJ.
 // idea {
 //     module {


### PR DESCRIPTION
This fixes so `.vscode` is properly ignored and fixes the mod_name field not updating the built jar file name.